### PR TITLE
Fix blocking bugs preventing the current-network app from running

### DIFF
--- a/Final Submission/Calgary_Transit_Analysis_Streamlit_App.py
+++ b/Final Submission/Calgary_Transit_Analysis_Streamlit_App.py
@@ -281,9 +281,9 @@ def main():
 
             comm_geo = gpd.read_file(census_file)
             dns_bound_data = pd.merge(final_current_df, comm_geo, how='left', left_on='NAME', right_on='name')
-            current_dns = gpd.GeoDataFrame(dns_bound_data[['name',"Low Income Index","Seniors Index","Rent Index","Total Community Index", "SS Frequency Index", "SS Capacity Index",'SS Coverage Index',"Community Demand Index","Average Supply Index",'Transit Gap','Letter Grade','geometry']])
-            
-            current_dns.to_file('final_data_set', driver='GeoJSON')
+            current_dns = gpd.GeoDataFrame(dns_bound_data[['NAME',"Low Income Index","Seniors Index","Rent Index","Total Community Index", "SS Frequency Index", "SS Capacity Index",'SS Coverage Index',"Community Demand Index","Average Supply Index",'Transit Gap','Letter Grade','geometry']])
+
+            current_dns.to_file('final_data_set.geojson', driver='GeoJSON')
             with open('final_data_set.geojson', 'r') as file:
                     geojson_data = json.load(file)
             fig2 = px.choropleth(

--- a/Final Submission/Instructions.txt
+++ b/Final Submission/Instructions.txt
@@ -1,6 +1,11 @@
 Instructions to run the program:
 
-1: Make sure the streamlit package is installed on your PC
-    - To install: pip install streamlit
+1: Install the required packages (streamlit alone is not enough - the app
+   also needs pandas, plotly, geopandas, and gtfs_functions):
+    - To install: pip install -r requirements.txt
+    - Note: gtfs_functions must be pinned to 2.5 (the latest release on
+      PyPI, 2.7.0, ships an empty package with no code) and h3 must stay
+      below version 4 (gtfs_functions relies on the old h3 v3 API). These
+      pins are already set in requirements.txt.
 2: Make sure your terminal is in the same directory as the program
 3: Run the following code: streamlit run *program_to_run*

--- a/Final Submission/requirements.txt
+++ b/Final Submission/requirements.txt
@@ -1,0 +1,7 @@
+streamlit
+pandas<3
+plotly
+geopandas
+openpyxl
+gtfs_functions==2.5
+h3<4


### PR DESCRIPTION
Verified both Streamlit apps end-to-end (real button click via streamlit.testing.v1.AppTest, plus a manual run of the compute path) against the actual data files in Final Submission/.

The future-network app ran cleanly. The current-network app crashed every run once it reached the Supply/Transit-Gap maps, from two bugs:

- current_dns.to_file('final_data_set', driver='GeoJSON') wrote a file literally named 'final_data_set' (no extension), but the next line opens 'final_data_set.geojson' -> FileNotFoundError every time.
- The GeoDataFrame kept the lowercase 'name' column from the census geojson instead of the 'NAME' column already used everywhere else in the pipeline, so the later choropleth code (which reads properties.NAME) raised KeyError('NAME').

Also add requirements.txt and update Instructions.txt: the repo had no dependency manifest at all, and the existing instructions only mention installing streamlit. In practice the app also needs pandas, plotly, geopandas, and gtfs_functions, and getting a working environment requires pinning versions: gtfs_functions' latest PyPI release (2.7.0) ships an empty wheel with no code, and the last working release (2.5) depends on the pre-v4 h3 API and pandas' legacy positional Series indexing that pandas 3.x removed.

https://claude.ai/code/session_01SYZyZ8xDpV7p2T99vBDLe8